### PR TITLE
refactor: use collection.insert_many() to seed database

### DIFF
--- a/dictionary/models.py
+++ b/dictionary/models.py
@@ -2,18 +2,17 @@ from django.db import models
 
 from mongoengine import *
 
-class JmdictSense(EmbeddedDocument):
+class JmdictSense(DynamicEmbeddedDocument):
     kanji_restrictions = ListField(StringField())
-    parts_of_speech = ListField(StringField())
+    pos = ListField(StringField())
     reading_restrictions = ListField(StringField())
-    glosses = ListField(StringField())
+    gloss = ListField(DictField())
 
 class JmdictEntry(Document):
-    entry_id = IntField()
-    kanji = ListField(StringField())
-    primary_reading = StringField()
-    readings = ListField(StringField())
-    senses = EmbeddedDocumentListField(JmdictSense)
+    ent_seq = IntField()
+    k_ele = ListField(DictField())
+    r_ele = ListField(DictField(), required=False)
+    sense = EmbeddedDocumentListField(JmdictSense)
 
     meta = {
         'collection': 'jmdict'

--- a/dictionary/templates/dictionary/search.html
+++ b/dictionary/templates/dictionary/search.html
@@ -4,7 +4,7 @@
 <div class="container">
     {% for result in page_obj %}
         {% include "dictionary/word-component.html" with data=result %}
-        <a href="{% url 'word' result.entry_id %}">Info &raquo;</a>
+        <a href="{% url 'word' result.ent_seq %}">Info &raquo;</a>
         <hr>
     {% endfor %}
 

--- a/dictionary/templates/dictionary/word-component.html
+++ b/dictionary/templates/dictionary/word-component.html
@@ -1,21 +1,42 @@
 {%  block word %}
 <div class="entry">
-    <h2>{{ data.primary_reading }}</h2>
-    <div class="soft">Readings</div>
-    <div>{{ data.readings|join:", " }}</div>
-    {% if data.kanji %}
-    <div class="soft">Forms</div>
-    <div>{{ data.kanji|join:", " }}</div>
+    {# Display entry heading as first kanji element if the entry has kanji elements #}
+    {# Else display as first reading element #}
+    {% if data.k_ele %}
+    <h2>{{ data.k_ele.0.keb }}</h2>
+    {% else %}
+    <h2>{{ data.r_ele.0.reb }}</h2>
     {% endif %}
-    {% for sense in data.senses %}
+
+    <div class="soft">Readings</div>
+    <div>
+    {% for reading in data.r_ele %}
+        {{ reading.reb }}{% if not forloop.last %},{% endif %}
+    {% endfor %}
+    </div>
+
+    {% if data.k_ele %}
+        <div class="soft">Forms</div>
+        <div>
+        {% for kanji in data.k_ele %}
+            {{ kanji.keb }}{% if not forloop.last %},{% endif %}
+        {% endfor %}
+        </div>
+    {% endif %}
+
+    {% for sense in data.sense %}
     <p>
-        <div class="soft">{{ sense.parts_of_speech|join:", " }}</div>
+        <div class="soft">{{ sense.pos|join:", " }}</div>
         <div>
             <span class="soft">{{ forloop.counter }}.</span>
-            <span>{{ sense.glosses|join:", " }}</span>
+            <span>        
+            {% for gloss in sense.gloss %}
+                {{ gloss.text }}{% if not forloop.last %},{% endif %}
+            {% endfor %}
+            </span>
         </div>
-        {% if sense.reading_elements %}
-        <div class="soft">Only applies to {{ sense.reading_restrictions|join:", " }}</div>
+        {% if sense.stagr %}
+        <div class="soft">Only applies to {{ sense.stagr|join:", " }}</div>
         {% endif %}
     </p>
     {% endfor %}

--- a/dictionary/urls.py
+++ b/dictionary/urls.py
@@ -5,5 +5,5 @@ from . import views
 urlpatterns = [
     path("", views.home, name="home"),
     path("search/", views.search, name="search"),
-    path("word/<entry_id>", views.word, name="word")
+    path("word/<ent_seq>", views.word, name="word")
 ]

--- a/dictionary/views.py
+++ b/dictionary/views.py
@@ -21,11 +21,11 @@ def rank_entry_search_results(results, query):
     ranked_results = []
     for result in results:
         ranked_result = {"result": result, "rank": 999}
-        for sense in result["senses"]:
-            for gloss in sense["glosses"]:
-                gloss_matches_query = re.search(query, gloss)
+        for sense in result["sense"]:
+            for gloss in sense["gloss"]:
+                gloss_matches_query = re.search(query, gloss["text"])
                 if gloss_matches_query:
-                    ranked_result["rank"] = min(ranked_result["rank"], len(gloss))
+                    ranked_result["rank"] = min(ranked_result["rank"], len(gloss["text"]))
         for i in range(0, len(ranked_results)):
             if ranked_result["rank"] < ranked_results[i]["rank"]:
                 ranked_results.insert(i, ranked_result)
@@ -49,7 +49,9 @@ def search(request):
     if cached_data:
         search_results = cached_data
     else:
+        print(query)
         matched_entries = JmdictEntry.objects.search_text(query).order_by('$text_score')[:100]
+        print(matched_entries)
         search_results = rank_entry_search_results(matched_entries, query)
         cache.set(query, search_results, CACHE_DURATION_SECONDS)
 
@@ -64,9 +66,9 @@ def search(request):
     template = loader.get_template("dictionary/search.html")
     return HttpResponse(template.render(context, request))
 
-def word(request, entry_id):
+def word(request, ent_seq):
     context = {
-        "response": JmdictEntry.objects.get(entry_id=entry_id)
+        "response": JmdictEntry.objects.get(ent_seq=ent_seq)
     }
 
     template = loader.get_template("dictionary/word.html")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==5.0.6
 pymongo==4.8.0
 mongoengine==0.27.0
+xmltodict==0.14.2

--- a/scripts/init_dictionary.py
+++ b/scripts/init_dictionary.py
@@ -1,9 +1,13 @@
 import logging
 import os
-import xml.etree.ElementTree
-import xml.dom
 
+import xmltodict
 from pymongo import MongoClient
+
+def postprocessor(path, key, value):
+    if key == "ent_seq":
+        return key, int(value)
+    return key.replace("#", ""), value
 
 if __name__ == "__main__":
     database = os.environ.get("MONGODB_DATABASE")
@@ -16,71 +20,19 @@ if __name__ == "__main__":
         handlers=[logging.StreamHandler()]
     )
 
+    with open(jmdict_path, "r", encoding="utf-8") as xml_file:
+        jmdict = xmltodict.parse(
+            xml_file.read(), disable_entities=False, 
+            force_list={'k_ele', 'r_ele', 'sense', 'gloss', 'stagk', 'stagr', 'pos', 'misc', 'ke_pri', 're_pri'},
+            postprocessor=postprocessor
+        )
+
     client = MongoClient(f"mongodb://db:27017/{database}")
     db = client[database]
     collection = db.jmdict
     collection.drop()
     collection.create_index(
-        [("kanji", "text"), ("readings", "text"), ("senses.glosses", "text")]
+        [("k_ele.keb", "text"), ("r_ele.reb", "text"), ("sense.gloss.text", "text")]
     )
 
-    element_tree = xml.etree.ElementTree.parse(jmdict_path)
-    root = element_tree.getroot()
-
-    for entry in root.findall("entry"):
-        entry_document = {
-            "entry_id": "",
-            "primary_reading": "",
-            "readings": [],
-            "kanji": [],
-            "senses": [],
-        }
-
-        entry_document["entry_id"] = int(entry.find("ent_seq").text)
-
-        reading_elements = entry.findall("r_ele")
-        if reading_elements:
-            for elem in reading_elements:
-                entry_document["readings"].append(elem.find("reb").text)
-
-        kanji_elements = entry.findall("k_ele")
-        if kanji_elements:
-            for elem in kanji_elements:
-                entry_document["kanji"].append(elem.find("keb").text)
-
-        if entry_document["kanji"]:
-            entry_document["primary_reading"] = entry_document["kanji"][0]
-        elif entry_document["readings"]:
-            entry_document["primary_reading"] = entry_document["readings"][0]
-
-        senses = entry.findall("sense")
-        for sense in senses:
-            sense_data = {
-                "parts_of_speech": [],
-                "reading_restrictions": [],
-                "kanji_restrictions": [],
-                "glosses": [],
-            }
-
-            poses = sense.findall("pos")
-            for pos in poses:
-                sense_data["parts_of_speech"].append(pos.text)
-
-            stagrs = sense.findall("stagr")
-            if stagrs:
-                for stagr in stagrs:
-                    sense_data["reading_restrictions"].append(stagr.text)
-
-            stagks = sense.findall("stagk")
-            if stagks:
-                for stagk in stagks:
-                    sense_data["kanji_restrictions"].append(stagk.text)
-
-            glosses = sense.findall("gloss")
-            for gloss in glosses:
-                sense_data["glosses"].append(gloss.text)
-
-            entry_document["senses"].append(sense_data)
-
-        logging.debug(f"Inserting entry for {entry_document['primary_reading']}: {entry_document}")
-        collection.insert_one(entry_document)
+    collection.insert_many(jmdict["JMdict"]["entry"])


### PR DESCRIPTION
Using collection.insert_many() to insert a dict containing all entries is much faster than using collection.insert_one() to insert individual entries.

Refactor init_dictionary.py to transform the JMdict file to a dict from XML using xmltodict, rather than writing custom processing per field. Perform some minor postprocessing to preserve types, remove special characters from dict keys, and force elements which may contain multiple values to be converted to lists.